### PR TITLE
refactor: switch from BrowserRouter to HashRouter in RouteProvider

### DIFF
--- a/src/providers/RouteProvider.tsx
+++ b/src/providers/RouteProvider.tsx
@@ -1,11 +1,11 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ProtectedRoute } from './ProtectedRoute ';
 import Login from '@/pages/Login/Login';
 import Chat from '@/pages/Chat/Chat';
 
 export const RouterProvider = () => {
   return (
-    <BrowserRouter>
+    <HashRouter>
       <Routes>
         <Route path="/" element={<Login />} />
 
@@ -15,6 +15,6 @@ export const RouterProvider = () => {
 
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   );
 };


### PR DESCRIPTION
## 🔀 **Pull Request Title**  
refactor: switch from BrowserRouter to HashRouter in RouteProvider
## 📌 **Description**
<!-- Explain the changes in this PR -->
We need to use HashRouter for GitHub Pages because it avoids 404 errors on client-side routes by keeping all routing logic in the browser, not on the server.
If we want to use BrowserRouter on GitHub Pages, we’d need to set up custom server-side redirects, which isn’t possible with static hosting like GH Pages.
## ✨ **Key Changes**  
1. **New Files:**  
   <!--`.env.example`: Environment variables template -->

2. **Modified Files:**  
 <!--`package.json`: Axios added -->
- RouterProvicer.tsx: switched BrowserRouter for HashRouter
3. **Dependencies Added:**  
   <!--```bash
    axios "^11.10.0"
   ``` -->

## 🗂️ **File Structure Changes**  
<!-- ```diff
src/
+ .env.example
``` -->

## 🧪 **Testing Instructions**
1. **Prerequisites:**  

2. **Test Cases:** 

## 📝 Additional Notes
- The Problem with GitHub Pages
GitHub Pages is a static file host.
It only serves files that exist in your repository.
If you visit https://username.github.io/my-app/about, GitHub Pages looks for a file at /about and returns a 404 if it doesn’t exist.
This breaks client-side routing for all routes except the root (/).
- How HashRouter Solves This
HashRouter uses the URL hash (#) to keep track of routes.
URLs look like: https://username.github.io/my-app/#/about
The part after # is never sent to the server; it’s handled entirely by the browser.
GitHub Pages always serves index.html, and your app handles the route after the #.

## 🖼️ Screenshots (optional)
<img width="320" height="auto" alt="image" src="https://github.com/user-attachments/assets/1dc5daee-6a95-4c61-99de-ab18af8859b8" />
➡️
<img width="320" height="auto" alt="image" src="https://github.com/user-attachments/assets/2d630f0c-a8ad-4e2b-9839-12639498f84c" />


