### PR TITLE
fix: typing animation applied only to the most recent bot message

### DIFF
--- a/src/components/ChatbotMessage.tsx
+++ b/src/components/ChatbotMessage.tsx
@@ -6,9 +6,10 @@ import ChatbotIcon from './icons/ChatbotIcon';
 export interface IChat {
   role: 'bot' | 'user';
   message: string;
+  isLastMsg?: boolean;
 }
 
-const ChatbotMessage = ({ role, message }: IChat) => {
+const ChatbotMessage = ({ role, message, isLastMsg }: IChat) => {
   const t = useTranslations();
 
   const fullText: string = message === 'processing' ? t.processing : message;
@@ -17,7 +18,7 @@ const ChatbotMessage = ({ role, message }: IChat) => {
 
   useEffect(() => {
     function typeWriter() {
-      if (role === 'bot') {
+      if (role === 'bot' && isLastMsg) {
         if (index < fullText.length) {
           if (element?.current) {
             element.current.textContent += fullText.charAt(index);

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -47,6 +47,8 @@ const Chat = () => {
     setLanguage(newLang);
   };
 
+  const lastBotIndex = chatHistory?.map(m => m.role).lastIndexOf('bot');
+
   return (
     <div className="container">
       <div className="chatbot-popup">
@@ -83,6 +85,7 @@ const Chat = () => {
               key={index}
               role={chat.role}
               message={chat.message}
+              isLastMsg={chat.role === 'bot' && index === lastBotIndex}
             />
           ))}
         </div>


### PR DESCRIPTION
## 🔀 **Pull Request Title**  
fix: typing animation applied only to the most recent bot message
## 📌 **Description**
<!-- Explain the changes in this PR -->
- Added a boolean prop isLastMsg that checks if it is the last message sent by the bot to apply typing animation only to it
## ✨ **Key Changes**  
1. **New Files:**  
<!--`.env.example`: Environment variables template -->

2. **Modified Files:**  
<!--`package.json`: Axios added -->
- ChatbotMessage.tsx
- Chat.tsx
3. **Dependencies Added:**  
   <!--```bash
    axios "^11.10.0"
   ``` -->

## 🗂️ **File Structure Changes**  
<!-- ```diff
src/
+ .env.example
``` -->

## 🧪 **Testing Instructions**
1. **Prerequisites:**  

2. **Test Cases:** 

## 📝 Additional Notes


## 🖼️ Screenshots (optional)

